### PR TITLE
Fix ampersand & being html encoded

### DIFF
--- a/link.js
+++ b/link.js
@@ -24,7 +24,7 @@ H5P.Link = (function ($) {
     if (parameters.linkWidget.protocol !== 'other') {
        url += parameters.linkWidget.protocol;
     }
-    url += parameters.linkWidget.url;
+    url += parameters.linkWidget.url.replace(/&amp;/g, '&');
 
     /**
      * Public. Attach.


### PR DESCRIPTION
When merged in, will replace occurrences of &amp; in URL with ampersand symbol &.

Currently, ampersands in URLs are HTML encoded and links entered as 
https://mywebsite.com/wp-admin/admin-ajax.php?action=h5p_embed&id=3
will be turned into
https://mywebsite.com/wp-admin/admin-ajax.php?action=h5p_embed&amp;id=3

Compare https://h5p.org/node/750169